### PR TITLE
Update links to relative paths

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,7 +1,7 @@
 # **Education sheets**
 Source: (mostly from NTUH)\
 [台大健康教育中心衛教單](https://www.ntuh.gov.tw/health/Fpage.action?muid=2652&fid=2521)\
-[OPD.ahk](https://github.com/chejuic/chejuic.github.io/raw/main/med/OPD.ahk)\
+[OPD.ahk](/med/OPD.ahk)\
 [居家照護確診個案接聽紀錄](https://redcap.ntuh.gov.tw/surveys/?s=74FDAMTWWM7J94PC)\
 [新冠肺炎患者口服抗病毒藥物治療同意書暨治療紀錄表](https://redcap.ntuh.gov.tw/surveys/?s=MLH8T3M3NPNDCYN8)\
 &nbsp;&nbsp;&nbsp;[(內部說明檔)](https://redcap.ntuh.gov.tw/surveys/?s=CrGnv2xFEeivWyMH)\
@@ -67,28 +67,28 @@ Source: (mostly from NTUH)\
 [糖尿病病友每日生活與血糖記錄](https://health.ntuh.gov.tw/health/%E8%A1%9B%E6%95%99%E5%96%AE%E5%BC%B5/%E7%B3%96%E5%B0%BF%E7%97%85%E7%94%9F%E6%B4%BB%E5%8F%8A%E8%A1%80%E7%B3%96%E8%A8%98%E9%8C%84.pdf)
 
 ## Diet
-[偏頭痛飲食處方](https://github.com/chejuic/chejuic.github.io/raw/main/med/食物與頭痛.pdf)\
-[便秘飲食處方 高纖維飲食](https://github.com/chejuic/chejuic.github.io/raw/main/med/如何吃到足夠的纖維素.pdf)\
-[飲食衛教單張_低普林飲食](https://github.com/chejuic/chejuic.github.io/raw/main/med/飲食衛教單張_低普林飲食.pdf)\
-[飲食衛教單張_低油飲食](https://github.com/chejuic/chejuic.github.io/raw/main/med/飲食衛教單張_低油飲食.pdf)\
+[偏頭痛飲食處方](/med/食物與頭痛.pdf)\
+[便秘飲食處方 高纖維飲食](/med/如何吃到足夠的纖維素.pdf)\
+[飲食衛教單張_低普林飲食](/med/飲食衛教單張_低普林飲食.pdf)\
+[飲食衛教單張_低油飲食](/med/飲食衛教單張_低油飲食.pdf)\
 [飲食衛教_減糖](https://www.hch.gov.tw/?aid=626&pid=62&page_name=detail&iid=706)\
-[飲食衛教單張_低渣飲食](https://github.com/chejuic/chejuic.github.io/raw/main/med/飲食衛教單張_低渣飲食.pdf)\
-[飲食衛教單張_低膽固醇飲食](https://github.com/chejuic/chejuic.github.io/raw/main/med/飲食衛教單張_低膽固醇飲食.pdf)\
-[飲食衛教單張_慢性腎臟病飲食](https://github.com/chejuic/chejuic.github.io/raw/main/med/飲食衛教單張_慢性腎臟病飲食.pdf)\
+[飲食衛教單張_低渣飲食](/med/飲食衛教單張_低渣飲食.pdf)\
+[飲食衛教單張_低膽固醇飲食](/med/飲食衛教單張_低膽固醇飲食.pdf)\
+[飲食衛教單張_慢性腎臟病飲食](/med/飲食衛教單張_慢性腎臟病飲食.pdf)\
 [護腎飲食六要六不要](https://docs.google.com/document/d/18xYAqSviY00urloX9DzI5vvEMGvyn2Ib0UCW-dKlfLE/)\
-[飲食衛教單張_糖尿病飲食](https://github.com/chejuic/chejuic.github.io/raw/main/med/飲食衛教單張_糖尿病飲食.pdf)\
+[飲食衛教單張_糖尿病飲食](/med/飲食衛教單張_糖尿病飲食.pdf)\
 [銀髮族營養養生](https://health.ntuh.gov.tw/health/forms/txt/15_%E8%80%81%E5%B9%B4%E7%87%9F%E9%A4%8A.pdf)
 
 ## Exercise
-[全民身體活動指引-成年人篇](https://github.com/chejuic/chejuic.github.io/raw/main/med/全民身體活動指引-成年人篇.pdf)\
-[全民身體活動指引-孕產婦篇](https://github.com/chejuic/chejuic.github.io/raw/main/med/全民身體活動指引-孕產婦篇.pdf)\
-[全民身體活動指引-氣喘篇](https://github.com/chejuic/chejuic.github.io/raw/main/med/全民身體活動指引-氣喘篇.pdf)\
-[全民身體活動指引-退化性關節炎篇](https://github.com/chejuic/chejuic.github.io/raw/main/med/全民身體活動指引-退化性關節炎篇.pdf)\
-[全民身體活動指引-高血壓與心臟疾病篇](https://github.com/chejuic/chejuic.github.io/raw/main/med/全民身體活動指引-高血壓與心臟疾病篇.pdf)\
-[全民身體活動指引-銀髮族篇](https://github.com/chejuic/chejuic.github.io/raw/main/med/全民身體活動指引-銀髮族篇.pdf)
+[全民身體活動指引-成年人篇](/med/全民身體活動指引-成年人篇.pdf)\
+[全民身體活動指引-孕產婦篇](/med/全民身體活動指引-孕產婦篇.pdf)\
+[全民身體活動指引-氣喘篇](/med/全民身體活動指引-氣喘篇.pdf)\
+[全民身體活動指引-退化性關節炎篇](/med/全民身體活動指引-退化性關節炎篇.pdf)\
+[全民身體活動指引-高血壓與心臟疾病篇](/med/全民身體活動指引-高血壓與心臟疾病篇.pdf)\
+[全民身體活動指引-銀髮族篇](/med/全民身體活動指引-銀髮族篇.pdf)
 
 ## Respiratory
-[低劑量電腦斷層共識宣言2020](https://github.com/chejuic/chejuic.github.io/raw/main/med/LDCT肺癌篩檢共識宣言.pdf)\
+[低劑量電腦斷層共識宣言2020](/med/LDCT肺癌篩檢共識宣言.pdf)\
 [LUNG-RADS分級+台灣版修正](https://drive.google.com/file/d/1Vx-R3TUtYF9IjWfivS7jFM1VVmF5jlQe/view?usp=sharing)\
 [肺結節計算機](https://fleischnerapp.com/)\
 [氣喘肺功能紀錄卡](http://www.taiwanasthma.com.tw/uploads/1/0/3/1/103176700/%E8%82%BA%E5%8A%9F%E8%83%BD%E7%B4%80%E9%8C%84%E5%8D%A1.pdf)\
@@ -100,25 +100,25 @@ Source: (mostly from NTUH)\
 [消化性潰瘍](https://epaper.ntuh.gov.tw/health/201207/pdf/消化性潰瘍會痊癒嗎.pdf)\
 [脂肪肝](https://health.ntuh.gov.tw/health/forms/txt/21_%E8%84%82%E8%82%AA%E8%82%9D.pdf)\
 [脂肪肝(圖文版)](https://health.ntuh.gov.tw/health/forms/21_%E8%84%82%E8%82%AA%E8%82%9D.pdf)\
-[C肝衛教(圖文版)](https://github.com/chejuic/chejuic.github.io/raw/main/med/C肝衛教.pdf)\
+[C肝衛教(圖文版)](/med/C肝衛教.pdf)\
 [急性腸胃炎衛教](https://www.hch.gov.tw/?aid=626&pid=7&page_name=detail&iid=77)
 
 ## CKD
 [腎臟保健](https://health.ntuh.gov.tw/health/forms/txt/12_%E8%85%8E%E8%87%9F%E4%BF%9D%E5%81%A5%E7%A7%98%E8%A8%A3.pdf)\
 [腎臟保健(圖文版)](https://health.ntuh.gov.tw/health/forms/12_%E8%85%8E%E8%87%9F%E4%BF%9D%E5%81%A5%E7%A7%98%E8%A8%A3.pdf)\
 [護腎飲食六要六不要](https://docs.google.com/document/d/18xYAqSviY00urloX9DzI5vvEMGvyn2Ib0UCW-dKlfLE/)\
-[飲食衛教單張_糖尿病飲食](https://github.com/chejuic/chejuic.github.io/raw/main/med/飲食衛教單張_糖尿病飲食.pdf)
+[飲食衛教單張_糖尿病飲食](/med/飲食衛教單張_糖尿病飲食.pdf)
 
 ## Neuro
 [腦中風防治觀念](https://health.ntuh.gov.tw/health/forms/txt/13_%E9%A0%90%E9%98%B2%E8%85%A6%E4%B8%AD%E9%A2%A8.pdf)\
 [腦中風防治觀念(圖文版)](https://health.ntuh.gov.tw/health/forms/13_%E8%85%A6%E4%B8%AD%E9%A2%A8%E9%98%B2%E6%B2%BB%E8%A7%80%E5%BF%B5.pdf)\
 [中風黃金時間](https://health.ntuh.gov.tw/health/forms/txt/16_%E4%B8%AD%E9%A2%A83%E5%B0%8F%E6%99%82.pdf)\
 [中風黃金時間(圖文版)](https://health.ntuh.gov.tw/health/forms/16_%E4%B8%AD%E9%A2%A83%E5%B0%8F%E6%99%82.pdf)\
-[偏頭痛管理](https://github.com/chejuic/chejuic.github.io/raw/main/med/偏頭痛管理.pdf)\
+[偏頭痛管理](/med/偏頭痛管理.pdf)\
 [頭痛日誌](https://taiwanheadache.org.tw/headache-diary-and-assessment-scale/)\
 [纖維肌痛症簡介](https://www.ntuh.gov.tw/neur/Fpage.action?fid=4198)\
-[ACR 1990 Diagnostic Criteria for Fibromyalgia](https://github.com/chejuic/chejuic.github.io/raw/main/med/頁面擷取自-纖維肌痛症指引.pdf)\
-[BPPV復健](https://github.com/chejuic/chejuic.github.io/raw/main/med/Brandt-Daroff%20%E9%81%8B%E5%8B%95%20(BPPV).pdf)\
+[ACR 1990 Diagnostic Criteria for Fibromyalgia](/med/頁面擷取自-纖維肌痛症指引.pdf)\
+[BPPV復健](/med/Brandt-Daroff%20%E9%81%8B%E5%8B%95%20(BPPV).pdf)\
 [眩暈與前庭復健](https://netreg.pntn.mohw.gov.tw/he/292%E7%9C%A9%E6%9A%88%E8%88%87%E5%89%8D%E5%BA%AD%E5%BE%A9%E5%81%A5.pdf)\
 [坐骨神經痛](http://epaper.ntuh.gov.tw/health/201210/pdf/%E6%B7%BA%E8%AB%87%E5%9D%90%E9%AA%A8%E7%A5%9E%E7%B6%93%E7%97%9B%E7%9A%84%E7%97%85%E5%9B%A0%E8%88%87%E6%B2%BB%E7%99%82.pdf)
 
@@ -130,17 +130,17 @@ Source: (mostly from NTUH)\
 [夜眠保養與失眠症](https://health.ntuh.gov.tw/health/forms/txt/18_%E5%A4%9C%E7%9C%A0%E4%BF%9D%E9%A4%8A%E8%88%87%E5%A4%B1%E7%9C%A0%E7%97%87.pdf)\
 [夜眠保養與失眠症(圖文版)](https://health.ntuh.gov.tw/health/forms/18_%E5%A4%9C%E7%9C%A0%E4%BF%9D%E9%A4%8A%E8%88%87%E5%A4%B1%E7%9C%A0%E7%97%87.pdf)\
 [睡眠日誌](https://www.ntuh.gov.tw/ckfinder_file/SLP/files/%E7%9D%A1%E7%9C%A0%E6%97%A5%E8%AA%8C.pdf)\
-[腹式呼吸 (台大陳錫中醫師)](https://github.com/chejuic/chejuic.github.io/raw/main/med/陳錫中呼吸放鬆訓練_p10_12.pdf)
+[腹式呼吸 (台大陳錫中醫師)](/med/陳錫中呼吸放鬆訓練_p10_12.pdf)
 
 ## Derm
 [正確剪指甲](http://www.kosodatedou.com/%E5%AD%90%E8%82%B2%E3%81%A6%E3%83%8D%E3%82%BF/post-518/)\
-[正確剪指甲(圖)](https://github.com/chejuic/chejuic.github.io/raw/main/med/20210208_084614648.jpg)
+[正確剪指甲(圖)](/med/20210208_084614648.jpg)
 
 ## Musculoskeletal
 [骨鬆預防](https://health.ntuh.gov.tw/health/forms/txt/08_骨鬆預防.pdf)\
 [骨鬆預防(圖文版)](https://health.ntuh.gov.tw/health/forms/08_%E9%A0%90%E9%98%B2%E9%AA%A8%E8%B3%AA%E7%96%8F%E9%AC%86%E7%97%87.pdf)\
 [認識關節炎](https://health.ntuh.gov.tw/health/forms/txt/09_%E8%AA%8D%E8%AD%98%E9%97%9C%E7%AF%80%E7%82%8E.pdf)\
-[五十肩復健](https://github.com/chejuic/chejuic.github.io/raw/main/med/新竹醫院-新聞稿-五十肩.pdf)\
+[五十肩復健](/med/新竹醫院-新聞稿-五十肩.pdf)\
 [預防頸椎關節退化](https://health.ntuh.gov.tw/health/new/6329.html)\
 [下背痛保健](https://health.ntuh.gov.tw/health/new/6364.html)\
 [顳顎關節障礙](https://www.ntuh.gov.tw/ckfinder_file/ENT/files/%E9%A1%B3%E9%A1%8E%E9%97%9C%E7%AF%80%E7%82%8E.pdf)\
@@ -158,11 +158,11 @@ Source: (mostly from NTUH)\
 
 ## Geriatrics
 [銀髮族營養養生](https://health.ntuh.gov.tw/health/forms/txt/15_%E8%80%81%E5%B9%B4%E7%87%9F%E9%A4%8A.pdf)\
-[全民身體活動指引-銀髮族篇](https://github.com/chejuic/chejuic.github.io/raw/main/med/全民身體活動指引-銀髮族篇.pdf)\
+[全民身體活動指引-銀髮族篇](/med/全民身體活動指引-銀髮族篇.pdf)\
 [提肛運動_男生版](https://www.ylh.gov.tw/?aid=612&pid=50&page_name=detail&iid=415)\
 [凱格爾運動_女生版](https://www.ylh.gov.tw/?aid=612&pid=50&page_name=detail&iid=414)\
-[銀髮族口腔保健](https://github.com/chejuic/chejuic.github.io/raw/main/med/老年口腔保健_摘錄.pdf.pdf)\
-[骨質疏鬆症治療選項](https://github.com/chejuic/chejuic.github.io/raw/main/med/Amgen_SDM_0515.pdf)
+[銀髮族口腔保健](/med/老年口腔保健_摘錄.pdf.pdf)\
+[骨質疏鬆症治療選項](/med/Amgen_SDM_0515.pdf)
 
 ## Palliative
 [Palliative Prognostic Score (PaP)](https://www.mdapp.co/palliative-prognostic-score-pap-calculator-401/)


### PR DESCRIPTION
原本 index.md 裡面很多 PDF 檔案是連到原本長長的 GitHub 位址，已經把它們改成了相對路徑（例如 /med/xxx.pdf）。這樣一來，使用者點擊時就會直接從新網域下載